### PR TITLE
Propose to create container from home

### DIFF
--- a/docs/atlas.md
+++ b/docs/atlas.md
@@ -16,7 +16,7 @@ to run in a containerized environment. This is done by running
 
     setupATLAS -c centos7+batch
 
-This will put you in a singularity container that will give you an environment similar to that of lxplus. You can then 
+from your home directory. This will put you in a singularity container that will give you an environment similar to that of lxplus. You can then 
 run all ATLAS software as you normally would.
 
 ### Submitting batch jobs


### PR DESCRIPTION
From my experience containers can have unexpected behavior if they are not created from the home directory (it starts all paths with /srv). Maybe it would be better to edit the command to be cd;setupATLAS -c centos7+batch? I get the felling that this way may be too subtle. What do you think?